### PR TITLE
cert: set certifiers during genesis in simulation

### DIFF
--- a/x/cert/genesis.go
+++ b/x/cert/genesis.go
@@ -25,7 +25,7 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, data types.GenesisState) {
 	if len(certifiers) > 0 {
 		cert := certifiers[0].Address
 		for _, platform := range platforms {
-			_ = k.CertifyPlatform(ctx, cert, platform.Address, platform.Description)
+			_ = k.CertifyPlatform(ctx, cert, platform.Validator, platform.Description)
 		}
 	}
 	for _, validator := range validators {

--- a/x/cert/handler.go
+++ b/x/cert/handler.go
@@ -73,7 +73,7 @@ func handleMsgCertifyCompilation(ctx sdk.Context, k Keeper, msg types.MsgCertify
 }
 
 func handleMsgCertifyPlatform(ctx sdk.Context, k Keeper, msg types.MsgCertifyPlatform) (*sdk.Result, error) {
-	if err := k.CertifyPlatform(ctx, msg.Certifier, msg.Validator.Bytes(), msg.Platform); err != nil {
+	if err := k.CertifyPlatform(ctx, msg.Certifier, msg.Validator, msg.Platform); err != nil {
 		return nil, err
 	}
 	return &sdk.Result{}, nil

--- a/x/cert/internal/keeper/querier.go
+++ b/x/cert/internal/keeper/querier.go
@@ -133,7 +133,7 @@ func queryPlatform(ctx sdk.Context, path []string, keeper Keeper) (res []byte, e
 		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, path[0])
 	}
 
-	platform, ok := keeper.GetPlatform(ctx, validator.Bytes())
+	platform, ok := keeper.GetPlatform(ctx, validator)
 	if !ok {
 		return nil, nil
 	}

--- a/x/cert/internal/types/genesis.go
+++ b/x/cert/internal/types/genesis.go
@@ -3,13 +3,15 @@ package types
 import (
 	"encoding/json"
 
+	"github.com/tendermint/tendermint/crypto"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // Platform is a genesis type for certified platform of a validator
 type Platform struct {
-	Address     sdk.ConsAddress
+	Validator   crypto.PubKey
 	Description string
 }
 

--- a/x/cert/internal/types/keys.go
+++ b/x/cert/internal/types/keys.go
@@ -119,8 +119,8 @@ func LibrariesStoreKey() []byte {
 }
 
 // PlatformStoreKey returns the kv-store key for the validator host platform certificate.
-func PlatformStoreKey(validator []byte) []byte {
-	return append(platformStoreKeyPrefix, validator...)
+func PlatformStoreKey(validator crypto.PubKey) []byte {
+	return append(platformStoreKeyPrefix, validator.Bytes()...)
 }
 
 // PlatformsStoreKey returns the kv-store key for accessing all platform certificates.

--- a/x/cert/simulation/decoder.go
+++ b/x/cert/simulation/decoder.go
@@ -27,10 +27,10 @@ func DecodeStore(cdc *codec.Codec, kvA, kvB tmkv.Pair) string {
 		return fmt.Sprintf("%v\n%v", validatorA, validatorB)
 
 	case bytes.Equal(kvA.Key[:1], types.PlatformsStoreKey()):
-		var descriptionA, descriptionB string
-		descriptionA = string(kvA.Value)
-		descriptionB = string(kvB.Value)
-		return fmt.Sprintf("%s\n%s", descriptionA, descriptionB)
+		var platformA, platformB types.Platform
+		cdc.MustUnmarshalBinaryLengthPrefixed(kvA.Value, &platformA)
+		cdc.MustUnmarshalBinaryLengthPrefixed(kvB.Value, &platformB)
+		return fmt.Sprintf("%v\n%v", platformA, platformB)
 
 	case bytes.Equal(kvA.Key[:1], types.CertificatesStoreKey()):
 		var certificateA, certificateB types.Certificate

--- a/x/cert/simulation/decoder_test.go
+++ b/x/cert/simulation/decoder_test.go
@@ -42,7 +42,7 @@ func TestDecodeStore(t *testing.T) {
 	}
 
 	platform := types.Platform{
-		Address:     sdk.GetConsAddress(RandomAccount().PubKey),
+		Validator:   RandomAccount().PubKey,
 		Description: "This is a test case.",
 	}
 
@@ -61,7 +61,7 @@ func TestDecodeStore(t *testing.T) {
 	KVPairs := kv.Pairs{
 		kv.Pair{Key: types.CertifierStoreKey(certifier.Address), Value: cdc.MustMarshalBinaryLengthPrefixed(&certifier)},
 		kv.Pair{Key: types.ValidatorStoreKey(validator.PubKey), Value: cdc.MustMarshalBinaryLengthPrefixed(&validator)},
-		kv.Pair{Key: types.PlatformStoreKey(platform.Address), Value: []byte(platform.Description)},
+		kv.Pair{Key: types.PlatformStoreKey(platform.Validator), Value: cdc.MustMarshalBinaryLengthPrefixed(&platform)},
 		kv.Pair{Key: types.LibraryStoreKey(library.Address), Value: cdc.MustMarshalBinaryLengthPrefixed(&library)},
 		kv.Pair{Key: types.CertifierAliasStoreKey(aliasCertifier.Alias), Value: cdc.MustMarshalBinaryLengthPrefixed(&aliasCertifier)},
 	}
@@ -72,7 +72,7 @@ func TestDecodeStore(t *testing.T) {
 	}{
 		{"Certifier", fmt.Sprintf("%v\n%v", certifier, certifier)},
 		{"Validator", fmt.Sprintf("%v\n%v", validator, validator)},
-		{"Platform", fmt.Sprintf("%s\n%s", platform.Description, platform.Description)},
+		{"Platform", fmt.Sprintf("%v\n%v", platform, platform)},
 		{"Library", fmt.Sprintf("%v\n%v", library, library)},
 		{"Alias certifier", fmt.Sprintf("%v\n%v", aliasCertifier, aliasCertifier)},
 		{"other", ""},

--- a/x/cert/simulation/genesis.go
+++ b/x/cert/simulation/genesis.go
@@ -2,21 +2,19 @@ package simulation
 
 import (
 	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/cosmos/cosmos-sdk/x/simulation"
 
 	"github.com/certikfoundation/shentu/x/cert/internal/types"
 )
 
 // RandomizedGenState creates a random genesis state for module simulation.
 func RandomizedGenState(simState *module.SimulationState) {
-	r := simState.Rand
 	gs := types.GenesisState{}
 
-	numOfCertifiers := r.Intn(10)
-	for i := 0; i < numOfCertifiers; i++ {
-		acc, _ := simulation.RandomAcc(r, simState.Accounts)
-		certifier := types.NewCertifier(acc.Address, "", nil, "")
-		gs.Certifiers = append(gs.Certifiers, certifier)
+	for _, acc := range simState.Accounts {
+		if simState.Rand.Intn(100) < 10 {
+			certifier := types.NewCertifier(acc.Address, "", nil, "")
+			gs.Certifiers = append(gs.Certifiers, certifier)
+		}
 	}
 
 	simState.GenState[types.ModuleName] = simState.Cdc.MustMarshalJSON(gs)

--- a/x/cert/simulation/genesis.go
+++ b/x/cert/simulation/genesis.go
@@ -1,10 +1,6 @@
 package simulation
 
 import (
-	"math/rand"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/x/simulation"
 
@@ -16,59 +12,12 @@ func RandomizedGenState(simState *module.SimulationState) {
 	r := simState.Rand
 	gs := types.GenesisState{}
 
-	numOfCertifiers := r.Intn(100)
+	numOfCertifiers := r.Intn(10)
 	for i := 0; i < numOfCertifiers; i++ {
-		gs.Certifiers = append(gs.Certifiers, GenerateACertifier(r))
-	}
-
-	numOfValidators := r.Intn(10)
-	for i := 0; i < numOfValidators; i++ {
-		gs.Validators = append(gs.Validators, GenerateAValidator(r))
-	}
-
-	numOfPlatforms := r.Intn(10)
-	for i := 0; i < numOfPlatforms; i++ {
-		gs.Platforms = append(gs.Platforms, GenerateAPlatform(r))
-	}
-
-	numOfLibrary := r.Intn(20)
-	for i := 0; i < numOfLibrary; i++ {
-		gs.Libraries = append(gs.Libraries, GenerateALibrary(r))
+		acc, _ := simulation.RandomAcc(r, simState.Accounts)
+		certifier := types.NewCertifier(acc.Address, "", nil, "")
+		gs.Certifiers = append(gs.Certifiers, certifier)
 	}
 
 	simState.GenState[types.ModuleName] = simState.Cdc.MustMarshalJSON(gs)
-}
-
-// GenerateACertifier returns an object of Certifier with random field values.
-func GenerateACertifier(r *rand.Rand) types.Certifier {
-	return types.Certifier{
-		Address:     simulation.RandomAccounts(r, 1)[0].Address,
-		Proposer:    simulation.RandomAccounts(r, 1)[0].Address,
-		Description: simulation.RandStringOfLength(r, 50),
-	}
-}
-
-// GenerateAValidator returns an object of Validator with random field values.
-func GenerateAValidator(r *rand.Rand) types.Validator {
-	randomAccount := simulation.RandomAccounts(r, 1)[0]
-	return types.Validator{
-		PubKey:    randomAccount.PubKey,
-		Certifier: randomAccount.Address,
-	}
-}
-
-// GenerateALibrary returns an object of Library with random field values.
-func GenerateALibrary(r *rand.Rand) types.Library {
-	return types.Library{
-		Address:   simulation.RandomAccounts(r, 1)[0].Address,
-		Publisher: simulation.RandomAccounts(r, 1)[0].Address,
-	}
-}
-
-// GenerateAPlatform returns an object of Platform with random field values.
-func GenerateAPlatform(r *rand.Rand) types.Platform {
-	return types.Platform{
-		Address:     sdk.GetConsAddress(simulation.RandomAccounts(r, 1)[0].PubKey),
-		Description: simulation.RandStringOfLength(r, 10),
-	}
 }

--- a/x/cert/simulation/operations.go
+++ b/x/cert/simulation/operations.go
@@ -15,7 +15,6 @@ import (
 )
 
 const (
-	OpWeightMsgProposeCertifier = "op_weight_msg_propose_certifier"
 	OpWeightMsgCertifyValidator = "op_weight_msg_certify_validator"
 	OpWeightMsgCertifyPlatform  = "op_weight_msg_certify_platform"
 	OpWeightMsgCertifyAuditing  = "op_weight_msg_certify_auditing"
@@ -25,12 +24,6 @@ const (
 // WeightedOperations creates an operation (with weight) for each type of message generators.
 func WeightedOperations(appParams simulation.AppParams, cdc *codec.Codec, ak types.AccountKeeper,
 	k keeper.Keeper) simulation.WeightedOperations {
-	var weightMsgProposeCertifier int
-	appParams.GetOrGenerate(cdc, OpWeightMsgProposeCertifier, &weightMsgProposeCertifier, nil,
-		func(_ *rand.Rand) {
-			weightMsgProposeCertifier = simappparams.DefaultWeightMsgSend
-		})
-
 	var weightMsgCertifyValidator int
 	appParams.GetOrGenerate(cdc, OpWeightMsgCertifyValidator, &weightMsgCertifyValidator, nil,
 		func(_ *rand.Rand) {
@@ -56,50 +49,10 @@ func WeightedOperations(appParams simulation.AppParams, cdc *codec.Codec, ak typ
 		})
 
 	return simulation.WeightedOperations{
-		simulation.NewWeightedOperation(weightMsgProposeCertifier, SimulateMsgProposeCertifier(k, ak)),
 		simulation.NewWeightedOperation(weightMsgCertifyValidator, SimulateMsgCertifyValidator(ak, k)),
 		simulation.NewWeightedOperation(weightMsgCertifyPlatform, SimulateMsgCertifyPlatform(ak, k)),
 		simulation.NewWeightedOperation(weightMsgCertifyAuditing, SimulateMsgCertifyAuditing(ak, k)),
 		simulation.NewWeightedOperation(weightMsgCertifyProof, SimulateMsgCertifyProof(ak, k)),
-	}
-}
-
-// SimulateMsgProposeCertifier generates a MsgProposeCertifier object with all of its fields randomized.
-func SimulateMsgProposeCertifier(k keeper.Keeper, ak types.AccountKeeper) simulation.Operation {
-	return func(r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simulation.Account, chainID string) (
-		simulation.OperationMsg, []simulation.FutureOperation, error) {
-		proposer, _ := simulation.RandomAcc(r, accs)
-		certifier := simulation.RandomAccounts(r, 1)[0]
-		description := simulation.RandStringOfLength(r, 10)
-		alias := simulation.RandStringOfLength(r, 5)
-
-		msg := types.NewMsgProposeCertifier(proposer.Address, certifier.Address, alias, description)
-
-		if len(k.GetAllCertifiers(ctx)) > 0 {
-			return simulation.NewOperationMsgBasic(types.ModuleName, "NoOp: certifier already exists", "", false, nil), nil, nil
-		}
-
-		account := ak.GetAccount(ctx, proposer.Address)
-		fees, err := simulation.RandomFees(r, ctx, account.SpendableCoins(ctx.BlockTime()))
-		if err != nil {
-			return simulation.NoOpMsg(types.ModuleName), nil, err
-		}
-
-		tx := helpers.GenTx(
-			[]sdk.Msg{msg},
-			fees,
-			helpers.DefaultGenTxGas,
-			chainID,
-			[]uint64{account.GetAccountNumber()},
-			[]uint64{account.GetSequence()},
-			proposer.PrivKey,
-		)
-
-		_, _, err = app.Deliver(tx)
-		if err != nil {
-			return simulation.NoOpMsg(types.ModuleName), nil, err
-		}
-		return simulation.NewOperationMsg(msg, true, ""), nil, nil
 	}
 }
 

--- a/x/cert/simulation/operations.go
+++ b/x/cert/simulation/operations.go
@@ -61,14 +61,18 @@ func WeightedOperations(appParams simulation.AppParams, cdc *codec.Codec, ak typ
 func SimulateMsgCertifyValidator(ak types.AccountKeeper, k keeper.Keeper) simulation.Operation {
 	return func(r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simulation.Account, chainID string) (
 		simulation.OperationMsg, []simulation.FutureOperation, error) {
-		certifier, _ := simulation.RandomAcc(r, accs)
+		certifiers := k.GetAllCertifiers(ctx)
+		certifier := certifiers[r.Intn(len(certifiers))]
+		var certifierAcc simulation.Account
+		for _, acc := range accs {
+			if acc.Address.Equals(certifier.Address) {
+				certifierAcc = acc
+				break
+			}
+		}
 		validator := simulation.RandomAccounts(r, 1)[0]
 
 		msg := types.NewMsgCertifyValidator(certifier.Address, validator.PubKey)
-
-		if !k.IsCertifier(ctx, certifier.Address) {
-			return simulation.NewOperationMsgBasic(types.ModuleName, "NoOp: not a certifier", "", false, nil), nil, nil
-		}
 
 		account := ak.GetAccount(ctx, certifier.Address)
 		fees, err := simulation.RandomFees(r, ctx, account.SpendableCoins(ctx.BlockTime()))
@@ -83,7 +87,7 @@ func SimulateMsgCertifyValidator(ak types.AccountKeeper, k keeper.Keeper) simula
 			chainID,
 			[]uint64{account.GetAccountNumber()},
 			[]uint64{account.GetSequence()},
-			certifier.PrivKey,
+			certifierAcc.PrivKey,
 		)
 
 		_, _, err = app.Deliver(tx)
@@ -99,15 +103,19 @@ func SimulateMsgCertifyValidator(ak types.AccountKeeper, k keeper.Keeper) simula
 func SimulateMsgCertifyPlatform(ak types.AccountKeeper, k keeper.Keeper) simulation.Operation {
 	return func(r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simulation.Account, chainID string) (
 		simulation.OperationMsg, []simulation.FutureOperation, error) {
-		certifier, _ := simulation.RandomAcc(r, accs)
+		certifiers := k.GetAllCertifiers(ctx)
+		certifier := certifiers[r.Intn(len(certifiers))]
+		var certifierAcc simulation.Account
+		for _, acc := range accs {
+			if acc.Address.Equals(certifier.Address) {
+				certifierAcc = acc
+				break
+			}
+		}
 		validator := simulation.RandomAccounts(r, 1)[0]
 		platform := simulation.RandStringOfLength(r, 10)
 
 		msg := types.NewMsgCertifyPlatform(certifier.Address, validator.PubKey, platform)
-
-		if !k.IsCertifier(ctx, certifier.Address) {
-			return simulation.NewOperationMsgBasic(types.ModuleName, "NoOp: not a certifier", "", false, nil), nil, nil
-		}
 
 		account := ak.GetAccount(ctx, certifier.Address)
 		fees, err := simulation.RandomFees(r, ctx, account.SpendableCoins(ctx.BlockTime()))
@@ -122,7 +130,7 @@ func SimulateMsgCertifyPlatform(ak types.AccountKeeper, k keeper.Keeper) simulat
 			chainID,
 			[]uint64{account.GetAccountNumber()},
 			[]uint64{account.GetSequence()},
-			certifier.PrivKey,
+			certifierAcc.PrivKey,
 		)
 
 		_, _, err = app.Deliver(tx)
@@ -138,15 +146,19 @@ func SimulateMsgCertifyPlatform(ak types.AccountKeeper, k keeper.Keeper) simulat
 func SimulateMsgCertifyAuditing(ak types.AccountKeeper, k keeper.Keeper) simulation.Operation {
 	return func(r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simulation.Account,
 		chainID string) (simulation.OperationMsg, []simulation.FutureOperation, error) {
-		certifier, _ := simulation.RandomAcc(r, accs)
+		certifiers := k.GetAllCertifiers(ctx)
+		certifier := certifiers[r.Intn(len(certifiers))]
+		var certifierAcc simulation.Account
+		for _, acc := range accs {
+			if acc.Address.Equals(certifier.Address) {
+				certifierAcc = acc
+				break
+			}
+		}
 		contract := simulation.RandomAccounts(r, 1)[0]
 		description := simulation.RandStringOfLength(r, 10)
 
 		msg := types.NewMsgCertifyGeneral("auditing", "address", contract.Address.String(), description, certifier.Address)
-
-		if !k.IsCertifier(ctx, certifier.Address) {
-			return simulation.NewOperationMsgBasic(types.ModuleName, "NoOp: not a certifier", "", false, nil), nil, nil
-		}
 
 		account := ak.GetAccount(ctx, certifier.Address)
 		fees, err := simulation.RandomFees(r, ctx, account.SpendableCoins(ctx.BlockTime()))
@@ -161,7 +173,7 @@ func SimulateMsgCertifyAuditing(ak types.AccountKeeper, k keeper.Keeper) simulat
 			chainID,
 			[]uint64{account.GetAccountNumber()},
 			[]uint64{account.GetSequence()},
-			certifier.PrivKey,
+			certifierAcc.PrivKey,
 		)
 
 		_, _, err = app.Deliver(tx)
@@ -177,15 +189,19 @@ func SimulateMsgCertifyAuditing(ak types.AccountKeeper, k keeper.Keeper) simulat
 func SimulateMsgCertifyProof(ak types.AccountKeeper, k keeper.Keeper) simulation.Operation {
 	return func(r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simulation.Account, chainID string) (
 		simulation.OperationMsg, []simulation.FutureOperation, error) {
-		certifier, _ := simulation.RandomAcc(r, accs)
+		certifiers := k.GetAllCertifiers(ctx)
+		certifier := certifiers[r.Intn(len(certifiers))]
+		var certifierAcc simulation.Account
+		for _, acc := range accs {
+			if acc.Address.Equals(certifier.Address) {
+				certifierAcc = acc
+				break
+			}
+		}
 		contract := simulation.RandomAccounts(r, 1)[0]
 		description := simulation.RandStringOfLength(r, 10)
 
 		msg := types.NewMsgCertifyGeneral("proof", "address", contract.Address.String(), description, certifier.Address)
-
-		if !k.IsCertifier(ctx, certifier.Address) {
-			return simulation.NewOperationMsgBasic(types.ModuleName, "NoOp: not a certifier", "", false, nil), nil, nil
-		}
 
 		account := ak.GetAccount(ctx, certifier.Address)
 		fees, err := simulation.RandomFees(r, ctx, account.SpendableCoins(ctx.BlockTime()))
@@ -200,7 +216,7 @@ func SimulateMsgCertifyProof(ak types.AccountKeeper, k keeper.Keeper) simulation
 			chainID,
 			[]uint64{account.GetAccountNumber()},
 			[]uint64{account.GetSequence()},
-			certifier.PrivKey,
+			certifierAcc.PrivKey,
 		)
 
 		_, _, err = app.Deliver(tx)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This is the first step to enable certifier voting round in gov simulation. Before this, cert simulation was full of NoOps because we didn't set real accounts to be certifiers in genesis. Now with valid certifiers set in genesis, cert simulation can generate successful txs and we can move on to fix gov simulation. 
* A set of sim accs are selected as certifiers during genesis in cert simulation. 
* Remove unnecessary contents from cert simulation's initial genesis. 
* Fix an inconsistency regarding cert platform type. 
* Remove propose-certifier tx simulation. 
* Improve the way tx simulations choose a certifier. 

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/certikfoundation/shentu/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/certikfoundation/shentu/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]"
