### PR TITLE
gov: End security voting period asap

### DIFF
--- a/x/cert/alias.go
+++ b/x/cert/alias.go
@@ -13,6 +13,7 @@ const (
 	Add                        = types.Add
 	Remove                     = types.Remove
 	CertificateTypeCompilation = types.CertificateTypeCompilation
+	MaxTimestamp               = keeper.MaxTimestamp
 )
 
 var (

--- a/x/gov/endblocker.go
+++ b/x/gov/endblocker.go
@@ -2,10 +2,12 @@ package gov
 
 import (
 	"fmt"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govTypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
+	"github.com/certikfoundation/shentu/x/cert"
 	"github.com/certikfoundation/shentu/x/gov/internal/keeper"
 	"github.com/certikfoundation/shentu/x/gov/internal/types"
 	"github.com/certikfoundation/shentu/x/shield"
@@ -44,65 +46,115 @@ func updateAbstain(ctx sdk.Context, k keeper.Keeper, proposal types.Proposal) {
 	}
 }
 
-// EndBlocker is called every block, removes inactive proposals, tallies active proposals and deletes/refunds deposits.
-// TODO refactor into smaller functions
-func EndBlocker(ctx sdk.Context, k keeper.Keeper) {
-	// delete inactive proposal from store and its deposits
-	removeInactiveProposals(ctx, k)
+func processActiveProposal(ctx sdk.Context, k keeper.Keeper, proposal types.Proposal) bool {
+	var (
+		tagValue     string
+		pass, veto   bool
+		tallyResults govTypes.TallyResult
+	)
 
-	// fetch active proposals whose voting periods have ended (are passed the block time)
-	k.IterateActiveProposalsQueue(ctx, ctx.BlockHeader().Time, func(proposal types.Proposal) bool {
-		var (
-			tagValue     string
-			pass, veto   bool
-			tallyResults govTypes.TallyResult
-		)
-
-		if proposal.Status == types.StatusCertifierVotingPeriod {
-			var endVoting bool
-			pass, endVoting, tallyResults = keeper.SecurityTally(ctx, k, proposal)
-			if !endVoting {
-				// Skip the rest of this iteration, because the proposal needs
-				// to go through the validator voting period now.
-				k.DeleteAllVotes(ctx, proposal.ProposalID)
-				k.ActivateVotingPeriod(ctx, proposal)
-				return false
-			}
-		} else {
-			pass, veto, tallyResults = keeper.Tally(ctx, k, proposal)
+	if proposal.Status == types.StatusCertifierVotingPeriod {
+		var endVoting bool
+		pass, endVoting, tallyResults = keeper.SecurityTally(ctx, k, proposal)
+		if !endVoting {
+			// Skip the rest of this iteration, because the proposal needs to go
+			// through the validator voting period now.
+			k.DeleteAllVotes(ctx, proposal.ProposalID)
+			k.ActivateVotingPeriod(ctx, proposal)
+			return false
 		}
+	} else {
+		pass, veto, tallyResults = keeper.Tally(ctx, k, proposal)
+	}
 
-		if veto {
-			k.DeleteDepositsByProposalID(ctx, proposal.ProposalID)
-			updateVeto(ctx, k, proposal)
-		} else {
-			k.RefundDepositsByProposalID(ctx, proposal.ProposalID)
-			if !pass {
-				updateAbstain(ctx, k, proposal)
-			}
+	if veto {
+		k.DeleteDepositsByProposalID(ctx, proposal.ProposalID)
+		updateVeto(ctx, k, proposal)
+	} else {
+		k.RefundDepositsByProposalID(ctx, proposal.ProposalID)
+		if !pass {
+			updateAbstain(ctx, k, proposal)
 		}
+	}
 
-		if pass {
-			handler := k.Router().GetRoute(proposal.ProposalRoute())
-			cacheCtx, writeCache := ctx.CacheContext()
+	if pass {
+		handler := k.Router().GetRoute(proposal.ProposalRoute())
+		cacheCtx, writeCache := ctx.CacheContext()
 
-			// The proposal handler may execute state mutating logic depending
-			// on the proposal content. If the handler fails, no state mutation
-			// is written and the error message is logged.
-			err := handler(cacheCtx, proposal.Content)
-			if err == nil {
-				proposal.Status = types.StatusPassed
-				tagValue = govTypes.AttributeValueProposalPassed
+		// The proposal handler may execute state mutating logic depending on the
+		// proposal content. If the handler fails, no state mutation is written and
+		// the error message is logged.
+		err := handler(cacheCtx, proposal.Content)
+		if err == nil {
+			proposal.Status = types.StatusPassed
+			tagValue = govTypes.AttributeValueProposalPassed
 
-				// write state to the underlying multi-store
-				writeCache()
-			} else {
-				proposal.Status = types.StatusFailed
-				tagValue = govTypes.AttributeValueProposalFailed
-			}
+			// write state to the underlying multi-store
+			writeCache()
 		} else {
-			proposal.Status = types.StatusRejected
-			tagValue = govTypes.AttributeValueProposalRejected
+			proposal.Status = types.StatusFailed
+			tagValue = govTypes.AttributeValueProposalFailed
+		}
+	} else {
+		proposal.Status = types.StatusRejected
+		tagValue = govTypes.AttributeValueProposalRejected
+	}
+
+	proposal.FinalTallyResult = tallyResults
+
+	k.SetProposal(ctx, proposal)
+	k.RemoveFromActiveProposalQueue(ctx, proposal.ProposalID, proposal.VotingEndTime)
+
+	// TODO log tallying result
+
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			govTypes.EventTypeActiveProposal,
+			sdk.NewAttribute(govTypes.AttributeKeyProposalID, fmt.Sprintf("%d", proposal.ProposalID)),
+			sdk.NewAttribute(govTypes.AttributeKeyProposalResult, tagValue),
+		),
+	)
+	return false
+}
+
+func processSecurityVote(ctx sdk.Context, k keeper.Keeper, proposal types.Proposal) bool {
+	var (
+		tagValue     string
+		pass         bool
+		tallyResults govTypes.TallyResult
+	)
+
+	// Only process proposals in the security voting period.
+	if proposal.Status != types.StatusCertifierVotingPeriod {
+		return false
+	}
+
+	var endVoting bool
+	pass, endVoting, tallyResults = keeper.SecurityTally(ctx, k, proposal)
+	if !pass {
+		// Do nothing, because the proposal still has time before the voting period
+		// ends.
+		return false
+	}
+	// Else: the proposal passed the certifier voting period.
+
+	if endVoting {
+		handler := k.Router().GetRoute(proposal.ProposalRoute())
+		cacheCtx, writeCache := ctx.CacheContext()
+
+		// The proposal handler may execute state mutating logic depending on the
+		// proposal content. If the handler fails, no state mutation is written and
+		// the error message is logged.
+		err := handler(cacheCtx, proposal.Content)
+		if err == nil {
+			proposal.Status = types.StatusPassed
+			tagValue = govTypes.AttributeValueProposalPassed
+
+			// write state to the underlying multi-store
+			writeCache()
+		} else {
+			proposal.Status = types.StatusFailed
+			tagValue = govTypes.AttributeValueProposalFailed
 		}
 
 		proposal.FinalTallyResult = tallyResults
@@ -119,6 +171,30 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) {
 				sdk.NewAttribute(govTypes.AttributeKeyProposalResult, tagValue),
 			),
 		)
-		return false
+	} else {
+		// Activate validator voting period
+		k.DeleteAllVotes(ctx, proposal.ProposalID)
+		k.ActivateVotingPeriod(ctx, proposal)
+	}
+	return false
+}
+
+// EndBlocker is called every block, removes inactive proposals, tallies active
+// proposals and deletes/refunds deposits.
+// TODO refactor into smaller functions
+func EndBlocker(ctx sdk.Context, k keeper.Keeper) {
+	// delete inactive proposal from store and its deposits
+	removeInactiveProposals(ctx, k)
+
+	// fetch active proposals whose voting periods have ended (are passed the
+	// block time)
+	k.IterateActiveProposalsQueue(ctx, ctx.BlockHeader().Time, func(proposal types.Proposal) bool {
+		return processActiveProposal(ctx, k, proposal)
+	})
+
+	// Iterate over all active proposals, regardless of end time, so that
+	// security voting can end as soon as a passing threshold is met.
+	k.IterateActiveProposalsQueue(ctx, time.Unix(cert.MaxTimestamp, 0), func(proposal types.Proposal) bool {
+		return processSecurityVote(ctx, k, proposal)
 	})
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #78 

## Description

Active proposals in the security voting period now end as soon as the have enough votes to pass. This is achieved by iterating over all active proposals in gov's endblocker, regardless of whether the voting period has ended, and passing proposals in the security voting period that are above the required threshold.
______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/certikfoundation/shentu/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/certikfoundation/shentu/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]"
