### PR TITLE
oracle: fix nondeterminism cause by time

### DIFF
--- a/x/oracle/client/cli/tx.go
+++ b/x/oracle/client/cli/tx.go
@@ -246,7 +246,7 @@ func GetCmdCreateTask(cdc *codec.Codec) *cobra.Command {
 			hours := viper.GetInt64(FlagValidDuration)
 			validDuration := time.Duration(hours) * time.Hour
 
-			msg := types.NewMsgCreateTask(contract, function, bounty, description, cliCtx.GetFromAddress(), wait, time.Now().UTC(), validDuration)
+			msg := types.NewMsgCreateTask(contract, function, bounty, description, cliCtx.GetFromAddress(), wait, validDuration)
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}

--- a/x/oracle/client/rest/tx.go
+++ b/x/oracle/client/rest/tx.go
@@ -73,7 +73,7 @@ func createTaskHandler(cliCtx context.CLIContext) http.HandlerFunc {
 		}
 		validDuration := time.Duration(hours) * time.Hour
 
-		msg := types.NewMsgCreateTask(req.Contract, req.Function, bounty, req.Description, creator, wait, time.Now(), validDuration)
+		msg := types.NewMsgCreateTask(req.Contract, req.Function, bounty, req.Description, creator, wait, validDuration)
 		if err = msg.ValidateBasic(); err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return

--- a/x/oracle/handler.go
+++ b/x/oracle/handler.go
@@ -120,9 +120,9 @@ func handleMsgCreateTask(ctx sdk.Context, k Keeper, msg types.MsgCreateTask) (*s
 	}
 	var expiration time.Time
 	if msg.ValidDuration.Microseconds() == 0 {
-		expiration = msg.Now.Add(taskParams.ExpirationDuration)
+		expiration = ctx.BlockTime().Add(taskParams.ExpirationDuration)
 	} else {
-		expiration = msg.Now.Add(msg.ValidDuration)
+		expiration = ctx.BlockTime().Add(msg.ValidDuration)
 	}
 
 	if err := k.CreateTask(ctx, msg.Contract, msg.Function, msg.Bounty, msg.Description,

--- a/x/oracle/internal/keeper/task.go
+++ b/x/oracle/internal/keeper/task.go
@@ -66,11 +66,6 @@ func (k Keeper) DeleteClosingTaskIDs(ctx sdk.Context, closingBlock int64) {
 	ctx.KVStore(k.storeKey).Delete(types.ClosingTaskIDsStoreKey(closingBlock))
 }
 
-// CheckExpiration checks whether a task is expired.
-func (k Keeper) IsExpired(task types.Task) bool {
-	return task.Expiration.Before(time.Now().UTC())
-}
-
 // CreateTask creates a new task.
 func (k Keeper) CreateTask(ctx sdk.Context, contract string, function string, bounty sdk.Coins,
 	description string, expiration time.Time, creator sdk.AccAddress, waitingBlocks int64) error {
@@ -99,7 +94,7 @@ func (k Keeper) RemoveTask(ctx sdk.Context, contract, function string, force boo
 	if err != nil {
 		return err
 	}
-	if !force && !k.IsExpired(task) {
+	if !force && !task.Expiration.Before(ctx.BlockTime()) {
 		return types.ErrNotExpired
 	}
 

--- a/x/oracle/internal/types/msgs.go
+++ b/x/oracle/internal/types/msgs.go
@@ -232,13 +232,12 @@ type MsgCreateTask struct {
 	Description   string
 	Creator       sdk.AccAddress
 	Wait          int64
-	Now           time.Time
 	ValidDuration time.Duration
 }
 
 // NewMsgCreateTask returns a new message for creating a task.
 func NewMsgCreateTask(contract, function string, bounty sdk.Coins, description string,
-	creator sdk.AccAddress, wait int64, now time.Time, validDuration time.Duration) MsgCreateTask {
+	creator sdk.AccAddress, wait int64, validDuration time.Duration) MsgCreateTask {
 	return MsgCreateTask{
 		Contract:      contract,
 		Function:      function,
@@ -246,7 +245,6 @@ func NewMsgCreateTask(contract, function string, bounty sdk.Coins, description s
 		Description:   description,
 		Creator:       creator,
 		Wait:          wait,
-		Now:           now,
 		ValidDuration: validDuration,
 	}
 }

--- a/x/oracle/simulation/operations.go
+++ b/x/oracle/simulation/operations.go
@@ -315,8 +315,7 @@ func SimulateMsgCreateTask(ak types.AuthKeeper, k keeper.Keeper) simulation.Oper
 		bounty := simulation.RandSubsetCoins(r, creatorAcc.SpendableCoins(ctx.BlockTime()))
 		wait := simulation.RandIntBetween(r, 5, 20)
 
-		msg := types.NewMsgCreateTask(contract, function, bounty, description, creator.Address,
-			int64(wait), time.Now(), time.Duration(0))
+		msg := types.NewMsgCreateTask(contract, function, bounty, description, creator.Address, int64(wait), time.Duration(0))
 
 		fees, err := simulation.RandomFees(r, ctx, creatorAcc.SpendableCoins(ctx.BlockTime()).Sub(bounty))
 		if err != nil {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX
Related: #XXX

## Description

`time.Now()` should not be used because it leads to nondeterministic states. Removed it from the oracle module.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/certikfoundation/shentu/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/certikfoundation/shentu/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]"
