### PR TITLE
shield: Fix staking check in deposit collateral

### DIFF
--- a/x/shield/keeper/collateral.go
+++ b/x/shield/keeper/collateral.go
@@ -13,8 +13,7 @@ func (k Keeper) DepositCollateral(ctx sdk.Context, from sdk.AccAddress, amount s
 		provider = k.addProvider(ctx, from)
 	}
 	// Check if there are enough delegations backing collaterals.
-	// DelegationBonded >= Collateral - Withdrawing + amount
-	if provider.DelegationBonded.LT(provider.Collateral.Add(amount).Sub(provider.Withdrawing)) {
+	if provider.DelegationBonded.LT(provider.Collateral.Add(amount)) {
 		return types.ErrInsufficientStaking
 	}
 

--- a/x/shield/simulation/operations.go
+++ b/x/shield/simulation/operations.go
@@ -285,7 +285,7 @@ func SimulateMsgDepositCollateral(k keeper.Keeper, ak types.AccountKeeper, sk ty
 		// collateral coins
 		provider, found := k.GetProvider(ctx, simAccount.Address)
 		if found {
-			available = provider.DelegationBonded.Sub(provider.Collateral.Sub(provider.Withdrawing))
+			available = provider.DelegationBonded.Sub(provider.Collateral)
 		}
 		collateralAmount, err := simulation.RandPositiveInt(r, available)
 		if err != nil {


### PR DESCRIPTION
Require withdrawing collaterals to be backed by bonded delegations as well.