### PR TITLE
Docs: Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ $ certik init node0 --chain-id shentuchain
 
 $ certik keys add jack
 
-$ certik add-genesis-account $(certik keys show jack -a) 200000000uctk
+$ certik add-genesis-account $(certik keys show jack -a) 10000000000000000uctk
 
 $ certik add-genesis-certifier $(certik keys show jack -a)
 
@@ -154,7 +154,7 @@ $ certik add-genesis-shield-admin $(certik keys show jack -a)
 Notification: Every transaction will need 5000uctk (certik token), so you'd better start with more than 5000uctk here.
 
 ```bash
-$ certik gentx --name jack --amount 10000000000000000uctk
+$ certik gentx jack 10000000000000000uctk --chain-id shentuchain
 $ certik collect-gentxs
 
 $ certik start


### PR DESCRIPTION
- Since we are adding just `200000000uctk` in the account initially, the upcoming genesis transaction using `10000000000000000uctk` will give **Not Enough Balance** error. So updated the initial amount since the transaction using `200000000uctk` failed to start the chain. 

- The command `certik gentx --name jack --amount 10000000000000000uctk` gives error -
 `unknown flag: --name`

![Screenshot from 2021-11-17 13-49-12](https://user-images.githubusercontent.com/43826321/142167288-6be8d865-895f-4b8d-90f6-9782dd233275.png)

- Updated the command as: `certik gentx jack 10000000000000000uctk --chain-id shentuchain`

![Screenshot from 2021-11-17 14-21-05](https://user-images.githubusercontent.com/43826321/142168085-1086d5af-75eb-443a-82cb-620e9695a8d2.png)


